### PR TITLE
Parquet and incorrect fields

### DIFF
--- a/R/OMLCollection.R
+++ b/R/OMLCollection.R
@@ -55,7 +55,8 @@ OMLCollection = R6Class("OMLCollection",
       parquet = getOption("mlr3oml.parquet", FALSE),
       test_server = getOption("mlr3oml.test_server", FALSE)
       ) {
-      super$initialize(id, cache, parquet, test_server, "collection")
+      private$.parquet = assert_flag(parquet)
+      super$initialize(id, cache, test_server, "collection")
     },
     #' @description
     #' Prints the object.
@@ -83,6 +84,12 @@ OMLCollection = R6Class("OMLCollection",
         )
       }
       return(private$.desc)
+    },
+    #' @field parquet (`logical(1)`)\cr
+    #' Whether to use parquet.
+    parquet = function(rhs) {
+      assert_ro_binding(rhs)
+      private$.parquet
     },
     #' @field main_entity_type (`character(n)`)\cr
     #'   The main entity type, either `"run"` or `"task"`.
@@ -170,7 +177,8 @@ OMLCollection = R6Class("OMLCollection",
     .tasks = NULL,
     .resamplings = NULL,
     .data = NULL,
-    .flows = NULL
+    .flows = NULL,
+    .parquet = NULL
   )
 )
 

--- a/R/OMLData.R
+++ b/R/OMLData.R
@@ -83,7 +83,8 @@ OMLData = R6Class("OMLData",
       parquet = getOption("mlr3oml.parquet", FALSE),
       test_server = getOption("mlr3oml.test_server", FALSE)
       ) {
-      super$initialize(id, cache, parquet, test_server, "data")
+      private$.parquet = assert_flag(parquet)
+      super$initialize(id, cache, test_server, "data")
     },
     #' @description
     #' Prints the object.
@@ -115,6 +116,17 @@ OMLData = R6Class("OMLData",
           cache_dir = self$cache_dir, server = self$server, test_server = self$test_server)
       }
       private$.qualities
+    },
+    #' @field tags (`character()`)\cr
+    #' Returns all tags of the object.
+    tags = function() {
+      self$desc$tag
+    },
+    #' @field parquet (`logical(1)`)\cr
+    #' Whether to use parquet.
+    parquet = function(rhs) {
+      assert_ro_binding(rhs)
+      private$.parquet
     },
     #' @field data (`data.table()`)\cr
     #' Returns the data (without the row identifier and ignore id columns).
@@ -196,6 +208,7 @@ OMLData = R6Class("OMLData",
     .features = NULL,
     .backend = NULL,
     .parquet_path = NULL,
+    .parquet = NULL,
     .get_backend = function() {
       if (!is.null(private$.backend)) {
         return(private$.backend)

--- a/R/OMLFlow.R
+++ b/R/OMLFlow.R
@@ -42,7 +42,8 @@ OMLFlow = R6Class("OMLFlow",
       parquet = getOption("mlr3oml.parquet", FALSE),
       test_server = getOption("mlr3oml.test_server", FALSE)
       ) {
-      super$initialize(id, cache, parquet, test_server, "flow")
+      private$.parquet = assert_flag(parquet)
+      super$initialize(id, cache, test_server, "flow")
     },
     #' @description
     #' Prints the object.
@@ -63,7 +64,21 @@ OMLFlow = R6Class("OMLFlow",
 
     #' @field dependencies (`character()`)\cr
     #' The dependencies of the flow.
-    dependencies = function() self$desc$dependencies
+    dependencies = function() self$desc$dependencies,
+    #' @field tags (`character()`)\cr
+    #' Returns all tags of the object.
+    tags = function() {
+      self$desc$tag
+    },
+    #' @field parquet (`logical(1)`)\cr
+    #' Whether to use parquet.
+    parquet = function(rhs) {
+      assert_ro_binding(rhs)
+      private$.parquet
+    }
+  ),
+  private = list(
+    .parquet = NULL
   )
 )
 

--- a/R/OMLObject.R
+++ b/R/OMLObject.R
@@ -41,7 +41,8 @@ OMLObject = R6Class("OMLObject",
   active = list(
     #' @field desc (`list()`)\cr
     #' Description of OpenML object.
-    desc = function() {
+    desc = function(rhs) {
+      assert_ro_binding(rhs)
       if (is.null(private$.desc)) {
         private$.desc = cached(
           get_desc_downloader(self$type),

--- a/R/OMLObject.R
+++ b/R/OMLObject.R
@@ -21,7 +21,6 @@ OMLObject = R6Class("OMLObject",
     initialize = function(
       id,
       cache = getOption("mlr3oml.cache", FALSE),
-      parquet = getOption("mlr3oml.parquet", FALSE),
       test_server = getOption("mlr3oml.test_server", FALSE),
       type
       ) {
@@ -30,7 +29,6 @@ OMLObject = R6Class("OMLObject",
 
       private$.id = assert_count(id, coerce = TRUE)
       private$.cache_dir = get_cache_dir(cache, test_server)
-      private$.parquet = assert_flag(parquet)
       private$.type = assert_choice(type, c("data", "flow", "study", "collection", "run", "task"))
       initialize_cache(self$cache_dir)
     },
@@ -53,12 +51,6 @@ OMLObject = R6Class("OMLObject",
       }
 
       private$.desc
-    },
-    #' @field parquet (`logical(1)`)\cr
-    #' Whether to use parquet.
-    parquet = function(rhs) {
-      assert_ro_binding(rhs)
-      private$.parquet
     },
     #' @template field_cache_dir
     cache_dir = function(rhs) {
@@ -86,11 +78,6 @@ OMLObject = R6Class("OMLObject",
     #' @field name (`character(1)`)\cr
     #' The name of the object.
     name = function() self$desc$name,
-    #' @field tags (`character()`)\cr
-    #' Returns all tags of the object.
-    tags = function() {
-      self$desc$tag
-    },
     #' @field type (`character()`)\cr
     #' The type of OpenML object (e.g. task, run, ...).
     type = function(rhs) {
@@ -106,7 +93,6 @@ OMLObject = R6Class("OMLObject",
   ),
   private = list(
     .desc = NULL,
-    .parquet = NULL,
     .cache_dir = NULL,
     .id = NULL,
     .server = NULL,

--- a/R/OMLRun.R
+++ b/R/OMLRun.R
@@ -56,7 +56,8 @@ OMLRun = R6Class("OMLRun",
       parquet = getOption("mlr3oml.parquet", FALSE),
       test_server = getOption("mlr3oml.test_server", FALSE)
       ) {
-      super$initialize(id, cache, parquet, test_server, "run")
+      private$.parquet = assert_flag(parquet)
+      super$initialize(id, cache, test_server, "run")
     },
     #' @description
     #' Prints the object.
@@ -84,6 +85,17 @@ OMLRun = R6Class("OMLRun",
         )
       }
       private$.flow
+    },
+    #' @field tags (`character()`)\cr
+    #' Returns all tags of the object.
+    tags = function() {
+      self$desc$tag
+    },
+    #' @field parquet (`logical(1)`)\cr
+    #' Whether to use parquet.
+    parquet = function(rhs) {
+      assert_ro_binding(rhs)
+      private$.parquet
     },
     #' @field task_id (`character(1)`)\cr
     #' The id of the task solved by this run.
@@ -129,7 +141,8 @@ OMLRun = R6Class("OMLRun",
     .prediction = NULL,
     .data = NULL,
     .flow = NULL,
-    .task_split = NULL
+    .task_split = NULL,
+    .parquet = NULL
   )
 )
 

--- a/R/OMLRun.R
+++ b/R/OMLRun.R
@@ -225,8 +225,8 @@ as_learner.OMLRun = function(x, task_type = NULL, ...) {
 
 #' @importFrom mlr3 as_data_backend
 #' @export
-as_data_backend.OMLRun = function(x, ...) {
-  as_data_backend(x$data, ...)
+as_data_backend.OMLRun = function(x, primary_key = NULL, ...) {
+  as_data_backend(x$data, primary_key = primary_key, ...)
 }
 
 #' @importFrom mlr3 as_resampling

--- a/R/OMLTask.R
+++ b/R/OMLTask.R
@@ -46,7 +46,8 @@ OMLTask = R6Class("OMLTask",
       parquet = getOption("mlr3oml.parquet", FALSE),
       test_server = getOption("mlr3oml.test_server", FALSE)
       ) {
-      super$initialize(id, cache, parquet, test_server, "task")
+      private$.parquet = assert_flag(parquet)
+      super$initialize(id, cache, test_server, "task")
     },
     #' @description
     #' Prints the object.
@@ -87,6 +88,17 @@ OMLTask = R6Class("OMLTask",
         )
       }
       return(private$.task_splits)
+    },
+    #' @field tags (`character()`)\cr
+    #' Returns all tags of the object.
+    tags = function() {
+      self$desc$tag
+    },
+    #' @field parquet (`logical(1)`)\cr
+    #' Whether to use parquet.
+    parquet = function(rhs) {
+      assert_ro_binding(rhs)
+      private$.parquet
     },
     #' @field name (`character(1)`)\cr
     #'   Name of the task, extracted from the task description.
@@ -148,17 +160,12 @@ OMLTask = R6Class("OMLTask",
     #' Name of the dataset (inferred from the task name).
     data_name = function() {
       strsplit(self$desc$task_name, split = " ")[[1]][[3]]
-    },
-    #' @field parquet (`logical(1)`)\cr
-    #' Whether to use parquet.
-    parquet = function(rhs) {
-      assert_ro_binding(rhs)
-      private$.parquet
     }
   ),
   private = list(
     .data = NULL,
-    .task_splits = NULL
+    .task_splits = NULL,
+    .parquet = NULL
   )
 )
 

--- a/R/download_parquet.R
+++ b/R/download_parquet.R
@@ -1,6 +1,25 @@
 download_parquet = function(data_id, server, desc = download_desc_data(data_id, server)) {
-  file = tempfile(fileext = ".parquet")
-  download.file(desc$minio_url, file)
-  return(file)
+  get_parquet(desc$minio_url, api_key = get_api_key())
 }
 
+get_parquet = function(url, ..., api_key = get_api_key(), retries = 3L) {
+  path = tempfile(fileext = ".parquet")
+  url = sprintf(url, ...)
+
+  lg$info("Retrieving parquet.", url = url, authenticated = !is.na(api_key))
+
+  for (retry in seq_len(retries)) {
+    response = download_file(url, path, api_key = api_key)
+
+    if (response$ok) {
+      lg$debug("Downloaded arquet file.", path = path)
+      return(path)
+    } else if (retry < retries && response$http_code >= 500L) {
+      delay = max(rnorm(1L, mean = 10), 0)
+      lg$debug("Server busy, retrying in %.2f seconds", delay, try = retry)
+      Sys.sleep(delay)
+    }
+  }
+
+  download_error(response)
+}

--- a/inst/testthat/helper_expectation.R
+++ b/inst/testthat/helper_expectation.R
@@ -116,7 +116,6 @@ expect_oml_collection = function(collection) {
   testthat::expect_true(test_logical(collection$cache_dir) || test_character(collection$cache_dir))
   expect_list(collection$desc, names = "unique")
   expect_string(collection$name, min.chars = 1L)
-  expect_character(collection$tags, null.ok = TRUE)
   expect_choice(collection$main_entity_type, c("task", "run"))
   expect_integer(collection$task_ids)
   expect_integer(collection$data_ids)

--- a/man-roxygen/param_parquet.R
+++ b/man-roxygen/param_parquet.R
@@ -1,2 +1,3 @@
 #' @param parquet (`logical(1)`)\cr
 #'   Whether to use parquet instead of arff.
+#'   If parquet is not available, it will fall back to arff.

--- a/man/oml_collection.Rd
+++ b/man/oml_collection.Rd
@@ -132,7 +132,8 @@ See field \code{cache} for an explanation of possible values.
 Defaults to value of option \code{"mlr3oml.cache"}, or \code{FALSE} if not set.}
 
 \item{\code{parquet}}{(\code{logical(1)})\cr
-Whether to use parquet instead of arff.}
+Whether to use parquet instead of arff.
+If parquet is not available, it will fall back to arff.}
 
 \item{\code{test_server}}{(\code{character(1)})\cr
 Whether to use the OpenML test server (https://test.openml.org/) or public server

--- a/man/oml_collection.Rd
+++ b/man/oml_collection.Rd
@@ -58,6 +58,9 @@ Vanschoren J, van Rijn JN, Bischl B, Torgo L (2014).
 \item{\code{desc}}{(\code{list()})\cr
 Colllection description (meta information), downloaded and converted from the JSON API response.}
 
+\item{\code{parquet}}{(\code{logical(1)})\cr
+Whether to use parquet.}
+
 \item{\code{main_entity_type}}{(\code{character(n)})\cr
 The main entity type, either \code{"run"} or \code{"task"}.}
 

--- a/man/oml_data.Rd
+++ b/man/oml_data.Rd
@@ -182,7 +182,8 @@ See field \code{cache} for an explanation of possible values.
 Defaults to value of option \code{"mlr3oml.cache"}, or \code{FALSE} if not set.}
 
 \item{\code{parquet}}{(\code{logical(1)})\cr
-Whether to use parquet instead of arff.}
+Whether to use parquet instead of arff.
+If parquet is not available, it will fall back to arff.}
 
 \item{\code{test_server}}{(\code{character(1)})\cr
 Whether to use the OpenML test server (https://test.openml.org/) or public server

--- a/man/oml_data.Rd
+++ b/man/oml_data.Rd
@@ -94,6 +94,12 @@ Vanschoren J, van Rijn JN, Bischl B, Torgo L (2014).
 Data set qualities (performance values), downloaded from the JSON API response and
 converted to a \code{\link[data.table:data.table]{data.table::data.table()}} with columns \code{"name"} and \code{"value"}.}
 
+\item{\code{tags}}{(\code{character()})\cr
+Returns all tags of the object.}
+
+\item{\code{parquet}}{(\code{logical(1)})\cr
+Whether to use parquet.}
+
 \item{\code{data}}{(\code{data.table()})\cr
 Returns the data (without the row identifier and ignore id columns).}
 

--- a/man/oml_flow.Rd
+++ b/man/oml_flow.Rd
@@ -46,6 +46,12 @@ The parameters of the flow.}
 
 \item{\code{dependencies}}{(\code{character()})\cr
 The dependencies of the flow.}
+
+\item{\code{tags}}{(\code{character()})\cr
+Returns all tags of the object.}
+
+\item{\code{parquet}}{(\code{logical(1)})\cr
+Whether to use parquet.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/oml_flow.Rd
+++ b/man/oml_flow.Rd
@@ -95,7 +95,8 @@ See field \code{cache} for an explanation of possible values.
 Defaults to value of option \code{"mlr3oml.cache"}, or \code{FALSE} if not set.}
 
 \item{\code{parquet}}{(\code{logical(1)})\cr
-Whether to use parquet instead of arff.}
+Whether to use parquet instead of arff.
+If parquet is not available, it will fall back to arff.}
 
 \item{\code{test_server}}{(\code{character(1)})\cr
 Whether to use the OpenML test server (https://test.openml.org/) or public server

--- a/man/oml_object.Rd
+++ b/man/oml_object.Rd
@@ -14,9 +14,6 @@ Don't use his class directly.
 \item{\code{desc}}{(\code{list()})\cr
 Description of OpenML object.}
 
-\item{\code{parquet}}{(\code{logical(1)})\cr
-Whether to use parquet.}
-
 \item{\code{cache_dir}}{(\code{logical(1)} | \code{character(1)})\cr
 Stores the location of the cache for objects retrieved from OpenML.
 If set to \code{FALSE}, caching is disabled.
@@ -36,9 +33,6 @@ The manual entry.}
 
 \item{\code{name}}{(\code{character(1)})\cr
 The name of the object.}
-
-\item{\code{tags}}{(\code{character()})\cr
-Returns all tags of the object.}
 
 \item{\code{type}}{(\code{character()})\cr
 The type of OpenML object (e.g. task, run, ...).}
@@ -65,7 +59,6 @@ Creates a new instance of this \link[R6:R6Class]{R6} class.
 \if{html}{\out{<div class="r">}}\preformatted{OMLObject$new(
   id,
   cache = getOption("mlr3oml.cache", FALSE),
-  parquet = getOption("mlr3oml.parquet", FALSE),
   test_server = getOption("mlr3oml.test_server", FALSE),
   type
 )}\if{html}{\out{</div>}}
@@ -80,9 +73,6 @@ OpenML id for the object.}
 \item{\code{cache}}{(\code{logical(1)} | \code{character(1)})\cr
 See field \code{cache} for an explanation of possible values.
 Defaults to value of option \code{"mlr3oml.cache"}, or \code{FALSE} if not set.}
-
-\item{\code{parquet}}{(\code{logical(1)})\cr
-Whether to use parquet instead of arff.}
 
 \item{\code{test_server}}{(\code{character(1)})\cr
 Whether to use the OpenML test server (https://test.openml.org/) or public server

--- a/man/oml_run.Rd
+++ b/man/oml_run.Rd
@@ -136,7 +136,8 @@ See field \code{cache} for an explanation of possible values.
 Defaults to value of option \code{"mlr3oml.cache"}, or \code{FALSE} if not set.}
 
 \item{\code{parquet}}{(\code{logical(1)})\cr
-Whether to use parquet instead of arff.}
+Whether to use parquet instead of arff.
+If parquet is not available, it will fall back to arff.}
 
 \item{\code{test_server}}{(\code{character(1)})\cr
 Whether to use the OpenML test server (https://test.openml.org/) or public server

--- a/man/oml_run.Rd
+++ b/man/oml_run.Rd
@@ -65,6 +65,12 @@ The id of the flow.}
 \item{\code{flow}}{(\link{OMLFlow})\cr
 The OpenML Flow.}
 
+\item{\code{tags}}{(\code{character()})\cr
+Returns all tags of the object.}
+
+\item{\code{parquet}}{(\code{logical(1)})\cr
+Whether to use parquet.}
+
 \item{\code{task_id}}{(\code{character(1)})\cr
 The id of the task solved by this run.}
 

--- a/man/oml_task.Rd
+++ b/man/oml_task.Rd
@@ -126,7 +126,8 @@ See field \code{cache} for an explanation of possible values.
 Defaults to value of option \code{"mlr3oml.cache"}, or \code{FALSE} if not set.}
 
 \item{\code{parquet}}{(\code{logical(1)})\cr
-Whether to use parquet instead of arff.}
+Whether to use parquet instead of arff.
+If parquet is not available, it will fall back to arff.}
 
 \item{\code{test_server}}{(\code{character(1)})\cr
 Whether to use the OpenML test server (https://test.openml.org/) or public server

--- a/man/oml_task.Rd
+++ b/man/oml_task.Rd
@@ -51,6 +51,12 @@ The estimation procedure, returns \code{NULL} if none is available.}
 \item{\code{task_splits}}{(\code{data.table()})\cr
 A data.table containing the splits as provided by OpenML.}
 
+\item{\code{tags}}{(\code{character()})\cr
+Returns all tags of the object.}
+
+\item{\code{parquet}}{(\code{logical(1)})\cr
+Whether to use parquet.}
+
 \item{\code{name}}{(\code{character(1)})\cr
 Name of the task, extracted from the task description.}
 
@@ -77,9 +83,6 @@ Name of the features (without targets of this \link{OMLTask}).}
 
 \item{\code{data_name}}{(\code{character()})\cr
 Name of the dataset (inferred from the task name).}
-
-\item{\code{parquet}}{(\code{logical(1)})\cr
-Whether to use parquet.}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/test_OMLData.R
+++ b/tests/testthat/test_OMLData.R
@@ -78,3 +78,29 @@ test_that("parquet works", {
 test_that("Can open help page for OpenML Data", {
   expect_error(OMLData$new(31)$help(), regexp = NA)
 })
+
+test_that("OMLData arff fallback works when parquet does not exist", {
+  odata = OMLData$new(31, parquet = TRUE, cache = FALSE)
+  odata$data
+  expect_true(inherits(odata$.__enclos_env__$private$.backend, "DataBackendDuckDB"))
+
+  odata = OMLData$new(31, parquet = TRUE, cache = FALSE)
+  odata$desc
+  # non-existing file
+  odata$.__enclos_env__$private$.desc$minio_url = "http://openml1.win.tue.nl/dataset31/dataset_000.pq"
+  odata$data
+  expect_true(inherits(odata$.__enclos_env__$private$.backend, "DataBackendDataTable"))
+})
+
+test_that("as_data_backend falls back to arff when parquet does not exist", {
+  odata = OMLData$new(31, parquet = TRUE, cache = FALSE)
+  odata$desc
+  # non-existing file
+  odata$.__enclos_env__$private$.desc$minio_url = "http://openml1.win.tue.nl/dataset31/dataset_000.pq"
+  backend = as_data_backend(odata)
+  expect_r6(backend, "DataBackendDataTable")
+
+  odata = OMLData$new(31, parquet = TRUE, cache = FALSE)
+  backend = as_data_backend(odata)
+  expect_r6(backend, "DataBackendDuckDB")
+})


### PR DESCRIPTION
This just ensures that objects don't have fields that don't make sense for them. 
Before e.g. `flow$parquet` and `collection$tags` was set but it did not make sense.
 