### PR TITLE
fix: bug with make.names in ignore cols

### DIFF
--- a/R/download_desc_data.R
+++ b/R/download_desc_data.R
@@ -15,10 +15,8 @@ parse_desc_data = function(desc) {
   desc$default_target_attribute = make.names(desc$default_target_attribute)
   desc$upload_date = strptime(desc$upload_date, format = "%Y-%m-%dT%H:%M:%S", tz = "UTC")
   desc$processing_date = strptime(desc$processing_date, format = "%Y-%m-%d %H:%M:%S", tz = "UTC")
-  # remove_named(desc, c("file_id", "description", "md5_checksum"))
-
   # OpenML (sometimes) uploaded the ignore_attributes comma-seperated
   ignore_attribute = map(desc$ignore_attribute, function(x) strsplit(x, ",")[[1L]])
-  desc$ignore_attribute = unlist(ignore_attribute)
+  desc$ignore_attribute = make.names(unlist(ignore_attribute))
   return(desc)
 }

--- a/tests/testthat/test_OMLData.R
+++ b/tests/testthat/test_OMLData.R
@@ -124,3 +124,12 @@ test_that("strings and nominals are distringuished for parquet files", {
   expect_class(dat[["instance_id"]], "character")
   expect_class(dat[["runstatus"]], "factor")
 })
+
+test_that("ignore features are properly ignored when names are converted", {
+  odata = odt(940, cache = TRUE)
+
+  # don't test using odata$desc$ignore, at least in the past this was not necessarily correct
+  # https://github.com/openml/OpenML/issues/1046
+  ignore = odata$features[get("is_ignore"), "name"][[1L]]
+  expect_true(all(ignore %nin% colnames(odata$data)))
+})


### PR DESCRIPTION
Because make.makes was not applied to the ignore columns, they were not discarded when accessing the data.

https://github.com/mlr-org/mlr3oml/issues/94