### PR TITLE
fix: parquet files work with renamings + bool conversion

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # mlr3oml 0.8.0-9000
 
+* Fix: Parquet datasets now work where columns simultaneously have to be renamed
+and converted.
 
 # mlr3oml 0.8.0
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -88,7 +88,8 @@ as_duckdb_backend_character = function(data, primary_key = NULL, factors) {
     tbl = "mlr3db_view_recoded"
     type = table_info$type
     vars = paste0("\"", vars_orig, "\"")
-    vars[type == "BOOLEAN"] = paste0(vars[type == "BOOLEAN"], "::VARCHAR")
+    tmp = vars[type == "BOOLEAN"]
+    vars[type == "BOOLEAN"] = paste0(tmp, "::VARCHAR as", tmp)
     vars = paste(vars, collapse = ", ")
 
     query = sprintf("CREATE OR REPLACE VIEW '%s' AS SELECT %s from '%s'", tbl, vars, tbl_prev)
@@ -124,7 +125,9 @@ as_duckdb_backend_character = function(data, primary_key = NULL, factors) {
     query = sprintf("CREATE OR REPLACE VIEW '%s' AS SELECT %s from '%s'",
       tbl, renamings, tbl_prev
     )
-    DBI::dbExecute(con, query)
+    out = DBI::dbExecute(con, query)
+
+    return(out)
   }
 
   backend = mlr3db::DataBackendDuckDB$new(con, table = tbl, primary_key = primary_key,

--- a/tests/testthat/test_OMLData.R
+++ b/tests/testthat/test_OMLData.R
@@ -106,7 +106,7 @@ test_that("as_data_backend falls back to arff when parquet does not exist", {
 })
 
 test_that("Logicals are converted to factor", {
-  odata = odt(1050, parquet = TRUE, cache = FALSE)
+  odata = odt(1050, parquet = TRUE)
   backend = as_data_backend(odata)
   # renaming worked
   assert_true("c" %in% backend$colnames)

--- a/tests/testthat/test_OMLData.R
+++ b/tests/testthat/test_OMLData.R
@@ -106,7 +106,7 @@ test_that("as_data_backend falls back to arff when parquet does not exist", {
 })
 
 test_that("Logicals are converted to factor", {
-  odata = odt(1050)
+  odata = odt(1050, parquet = TRUE, cache = FALSE)
   backend = as_data_backend(odata)
   # renaming worked
   assert_true("c" %in% backend$colnames)
@@ -174,4 +174,10 @@ test_that("download runs without error", {
   # simple sanity check
   out = capture.output(with_cache(odt(31)$download(), cache = FALSE))
   expect_true(length(out) == 4L)
+})
+
+test_that("Renamings and boolean conversion works, datetime works", {
+  odata = odt(41707, parquet = TRUE)
+  expect_data_table(odata$data)
+  expect_class(odata$data[["Timestamp"]], "POSIXct")
 })


### PR DESCRIPTION
Earlier, the table_info PRAGMA returned invalid names for the boolean columns that were converted to categoricals. Now we keep the name as it was using an explicit
"x::VARCHAR as x" instead of only "x::VARCHAR"